### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/neilcaldwell/PomoTimer/security/code-scanning/1](https://github.com/neilcaldwell/PomoTimer/security/code-scanning/1)

To fix the problem, you should explicitly set the permissions for the workflow to ensure the GITHUB_TOKEN only has the minimum required privileges. Since the workflow only checks out code, installs dependencies, and runs tests, it does not need write permissions. The best way to fix this is to add a `permissions` block at the root level of the workflow, above the `jobs:` key. The recommended setting is `contents: read`, which allows the workflow to read repository contents (necessary for `actions/checkout`), but restricts any write access. Edit `.github/workflows/node.js.yml`, and insert the following block after the `name: Node.js CI` line, before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
